### PR TITLE
Make chart full-width with dark theme styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,14 +1,15 @@
 .app-shell {
   min-height: 100vh;
-  padding: clamp(24px, 5vw, 48px);
+  padding: clamp(20px, 4vw, 40px);
   background: var(--background);
   display: flex;
+  justify-content: center;
 }
 
 .app-content {
   flex: 1;
-  max-width: 1400px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   display: flex;
   flex-direction: column;
   gap: clamp(24px, 4vw, 32px);
@@ -24,11 +25,13 @@
   margin: 0;
   font-size: clamp(1.9rem, 3vw, 2.6rem);
   letter-spacing: -0.02em;
+  color: var(--text-primary);
 }
 
 .app-subtitle {
   margin: 0;
   font-size: 1rem;
+  color: var(--text-secondary);
 }
 
 .controls {
@@ -48,26 +51,26 @@
   padding: 0.55rem 2.75rem 0.55rem 0.85rem;
   border-radius: 10px;
   border: 1px solid var(--border);
-  background: var(--surface) url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8"><path fill="%23475569" d="M1.41.59 6 5.17 10.59.59 12 2l-6 6-6-6z"/></svg>') no-repeat right 0.75rem center;
+  background: var(--surface) url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8"><path fill="%23cbd5f5" d="M1.41.59 6 5.17 10.59.59 12 2l-6 6-6-6z"/></svg>') no-repeat right 0.75rem center;
   background-size: 12px;
   color: var(--text-primary);
   font: inherit;
   min-width: 220px;
-  box-shadow: 0 6px 16px -12px rgba(15, 23, 42, 0.6);
+  box-shadow: 0 6px 20px -12px rgba(2, 6, 23, 0.75);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .family-select:focus {
   outline: none;
   border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.28);
 }
 
 .chart-card {
   background: var(--surface);
   border-radius: 18px;
   padding: clamp(18px, 3vw, 32px);
-  box-shadow: 0 24px 60px -40px rgba(15, 23, 42, 0.55);
+  box-shadow: 0 24px 60px -38px rgba(2, 6, 23, 0.85);
   display: flex;
   flex-direction: column;
   gap: clamp(16px, 3vw, 24px);
@@ -82,10 +85,12 @@
 .chart-heading h2 {
   margin: 0;
   font-size: clamp(1.4rem, 2.5vw, 1.9rem);
+  color: var(--text-primary);
 }
 
 .chart-heading p {
   margin: 0;
+  color: var(--text-secondary);
 }
 
 .chart-wrapper {
@@ -97,12 +102,13 @@
   background: var(--surface);
   border-radius: 18px;
   padding: clamp(18px, 3vw, 30px);
-  box-shadow: 0 18px 46px -36px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 46px -32px rgba(2, 6, 23, 0.8);
 }
 
 .insights-card h3 {
   margin-top: 0;
   margin-bottom: 0.9rem;
+  color: var(--text-primary);
 }
 
 .insights-card ul {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,11 +135,12 @@ const VLMBubbleChart = () => {
       return (
         <div
           style={{
-            backgroundColor: 'white',
+            backgroundColor: 'var(--surface-elevated)',
             padding: '10px 12px',
             border: '1px solid var(--border)',
             borderRadius: '8px',
-            boxShadow: '0 12px 24px -18px rgba(15, 23, 42, 0.45)',
+            boxShadow: '0 12px 28px -18px rgba(2, 6, 23, 0.7)',
+            color: 'var(--text-primary)',
           }}
         >
           <p style={{ fontWeight: 600, margin: '0 0 6px 0', color: 'var(--text-primary)' }}>
@@ -196,7 +197,7 @@ const VLMBubbleChart = () => {
           <div className="chart-wrapper">
             <ResponsiveContainer width="100%" height="100%">
               <ScatterChart margin={{ top: 20, right: 20, bottom: 60, left: 60 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--grid)" />
                 <XAxis
                   dataKey="x"
                   type="number"

--- a/src/index.css
+++ b/src/index.css
@@ -6,14 +6,16 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color-scheme: light;
-  color: #0f172a;
-  background-color: #f1f5f9;
-  --text-primary: #0f172a;
-  --text-secondary: #475569;
-  --surface: #ffffff;
-  --border: #e2e8f0;
-  --background: #f1f5f9;
+  color-scheme: dark;
+  color: #e2e8f0;
+  background-color: #020617;
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --surface: rgba(15, 23, 42, 0.8);
+  --surface-elevated: rgba(15, 23, 42, 0.92);
+  --border: rgba(148, 163, 184, 0.24);
+  --background: radial-gradient(circle at top, #1e3a8a 0%, #0f172a 45%, #020617 100%);
+  --grid: rgba(148, 163, 184, 0.18);
 }
 
 *, *::before, *::after {
@@ -23,7 +25,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: var(--background);
+  background: var(--background);
   color: var(--text-primary);
 }
 


### PR DESCRIPTION
## Summary
- switch the global design tokens to a dark theme palette for correct text contrast
- widen the application shell so the bubble chart can span the full viewport width
- align card, tooltip, and grid styling with the new theme variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5394ddb0c832586d9a8242c29671f